### PR TITLE
Add 'witness' flag to zeroTracer config

### DIFF
--- a/turbo/trie/witness.go
+++ b/turbo/trie/witness.go
@@ -15,7 +15,7 @@ type WitnessStorage interface {
 // WitnessVersion represents the current version of the block witness
 // in case of incompatible changes it should be updated and the code to migrate the
 // old witness format should be present
-const WitnessVersion = uint8(1)
+const WitnessVersion = uint8(0)
 
 // WitnessHeader contains version information and maybe some future format bits
 // the version is always the 1st bit.


### PR DESCRIPTION
This flag will allow user to include or exclude witness in the result of zeroTracer. 
This PR also adds field `txHash` back to result output of zeroTracer. The purpose is to unify the output format of zeroTracer with the rest of tracers. Also, a minor change that sets witness version header from 1 to 0.


## Usages

### Include witness in tracer output:

```bash
curl http://127.0.0.1:8545   -X POST   -H "Content-Type: application/json"   --data '{"method":"debug_traceBlockByNumber","params":["0x58", {"tracer": "zeroTracer",  "tracerConfig": {"witness": true}}],"id":1,"jsonrpc":"2.0"}' 
```

### Exclude witness in tracer output:

```bash
curl http://127.0.0.1:8545   -X POST   -H "Content-Type: application/json"   --data '{"method":"debug_traceBlockByNumber","params":["0x58", {"tracer": "zeroTracer",  "tracerConfig": {"witness": false}}],"id":1,"jsonrpc":"2.0"}' 
```

By default, `witness` flag is set to false. Hence, the query below will have the same output as the command above:

```bash
curl http://127.0.0.1:8545   -X POST   -H "Content-Type: application/json"   --data '{"method":"debug_traceBlockByNumber","params":["0x58", {"tracer": "zeroTracer"}],"id":1,"jsonrpc":"2.0"}' 
```

