### PR TITLE
[bugfix] Include code in the witness on GetCodeHash

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -260,6 +260,10 @@ func (sdb *IntraBlockState) GetCodeHash(addr libcommon.Address) libcommon.Hash {
 	if stateObject == nil || stateObject.deleted {
 		return libcommon.Hash{}
 	}
+
+	// Plonky2: if the code is not nil, we need to include code in the witness by calling GetCodeSize
+	sdb.GetCodeSize(addr)
+
 	return libcommon.BytesToHash(stateObject.CodeHash())
 }
 


### PR DESCRIPTION
The commit enforces bytecode to be included in block witness when `EXTCODEHASH` is called.
It will fix the issue described in https://github.com/0xPolygonZero/erigon/issues/11