### PR TITLE
Relax the condition check for err in zero tracer

### DIFF
--- a/core/vm/evmtypes/evmtypes.go
+++ b/core/vm/evmtypes/evmtypes.go
@@ -81,6 +81,7 @@ type IntraBlockState interface {
 	GetState(address common.Address, slot *common.Hash, outValue *uint256.Int)
 	SetState(common.Address, *common.Hash, uint256.Int)
 	HasLiveAccount(addr common.Address) bool
+	SeenAccount(addr common.Address) bool
 	HasLiveState(addr common.Address, key *common.Hash) bool
 
 	GetTransientState(addr common.Address, key common.Hash) uint256.Int

--- a/eth/tracers/native/zero.go
+++ b/eth/tracers/native/zero.go
@@ -27,17 +27,16 @@ func init() {
 }
 
 type zeroTracer struct {
-	noopTracer     // stub struct to mock not used interface methods
-	env            *vm.EVM
-	tx             types.TxnInfo
-	gasLimit       uint64      // Amount of gas bought for the whole tx
-	interrupt      atomic.Bool // Atomic flag to signal execution interruption
-	reason         error       // Textual reason for the interruption
-	ctx            *tracers.Context
-	to             *libcommon.Address
-	txStatus       uint64
-	addrOpCodes    map[libcommon.Address]map[vm.OpCode]struct{}
-	wasLoadedToIBS map[libcommon.Address]bool
+	noopTracer  // stub struct to mock not used interface methods
+	env         *vm.EVM
+	tx          types.TxnInfo
+	gasLimit    uint64      // Amount of gas bought for the whole tx
+	interrupt   atomic.Bool // Atomic flag to signal execution interruption
+	reason      error       // Textual reason for the interruption
+	ctx         *tracers.Context
+	to          *libcommon.Address
+	txStatus    uint64
+	addrOpCodes map[libcommon.Address]map[vm.OpCode]struct{}
 }
 
 func newZeroTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, error) {
@@ -45,9 +44,8 @@ func newZeroTracer(ctx *tracers.Context, cfg json.RawMessage) (tracers.Tracer, e
 		tx: types.TxnInfo{
 			Traces: make(map[libcommon.Address]*types.TxnTrace),
 		},
-		ctx:            ctx,
-		addrOpCodes:    make(map[libcommon.Address]map[vm.OpCode]struct{}),
-		wasLoadedToIBS: make(map[libcommon.Address]bool),
+		ctx:         ctx,
+		addrOpCodes: make(map[libcommon.Address]map[vm.OpCode]struct{}),
 	}, nil
 }
 
@@ -178,8 +176,10 @@ func (t *zeroTracer) CaptureTxEnd(restGas uint64) {
 
 	toDelete := make([]libcommon.Address, 0)
 	for addr := range t.tx.Traces {
+		// Check again if the account was accessed through IntraBlockState
+		seenAccount := t.env.IntraBlockState().SeenAccount(addr)
 		// If an account was never accessed through IntraBlockState, it means that never there was an OpCode that read into it or checks whether it exists in the state trie, and therefore we don't need the trace of it.
-		if _, ok := t.wasLoadedToIBS[addr]; !ok {
+		if !seenAccount {
 			toDelete = append(toDelete, addr)
 			continue
 		}
@@ -344,11 +344,6 @@ func (t *zeroTracer) Stop(err error) {
 }
 
 func (t *zeroTracer) addAccountToTrace(addr libcommon.Address) {
-	hasLiveAccount := t.env.IntraBlockState().HasLiveAccount(addr)
-	if hasLiveAccount {
-		t.wasLoadedToIBS[addr] = true
-	}
-
 	if _, ok := t.tx.Traces[addr]; ok {
 		return
 	}

--- a/eth/tracers/native/zero.go
+++ b/eth/tracers/native/zero.go
@@ -347,10 +347,6 @@ func (t *zeroTracer) addAccountToTrace(addr libcommon.Address) {
 }
 
 func (t *zeroTracer) addSLOADToAccount(addr libcommon.Address, key libcommon.Hash) {
-	if !t.env.IntraBlockState().HasLiveState(addr, &key) {
-		return
-	}
-
 	var value uint256.Int
 	t.env.IntraBlockState().GetState(addr, &key, &value)
 	t.tx.Traces[addr].StorageReadMap[key] = struct{}{}
@@ -359,19 +355,11 @@ func (t *zeroTracer) addSLOADToAccount(addr libcommon.Address, key libcommon.Has
 }
 
 func (t *zeroTracer) addSSTOREToAccount(addr libcommon.Address, key libcommon.Hash, value *uint256.Int) {
-	if !t.env.IntraBlockState().HasLiveState(addr, &key) {
-		return
-	}
-
 	t.tx.Traces[addr].StorageWritten[key] = value
 	t.addOpCodeToAccount(addr, vm.SSTORE)
 }
 
 func (t *zeroTracer) addOpCodeToAccount(addr libcommon.Address, op vm.OpCode) {
-	if !t.env.IntraBlockState().HasLiveAccount(addr) {
-		return
-	}
-
 	if t.addrOpCodes[addr] == nil {
 		t.addrOpCodes[addr] = make(map[vm.OpCode]struct{})
 	}

--- a/eth/tracers/native/zero.go
+++ b/eth/tracers/native/zero.go
@@ -198,7 +198,9 @@ func (t *zeroTracer) CaptureTxEnd(restGas uint64) {
 		if len(trace.StorageReadMap) > 0 && hasLiveAccount {
 			trace.StorageRead = make([]libcommon.Hash, 0, len(trace.StorageReadMap))
 			for k := range trace.StorageReadMap {
-				trace.StorageRead = append(trace.StorageRead, k)
+				if t.env.IntraBlockState().HasLiveState(addr, &k) {
+					trace.StorageRead = append(trace.StorageRead, k)
+				}
 			}
 		} else {
 			trace.StorageRead = nil
@@ -347,10 +349,7 @@ func (t *zeroTracer) addAccountToTrace(addr libcommon.Address) {
 }
 
 func (t *zeroTracer) addSLOADToAccount(addr libcommon.Address, key libcommon.Hash) {
-	var value uint256.Int
-	t.env.IntraBlockState().GetState(addr, &key, &value)
 	t.tx.Traces[addr].StorageReadMap[key] = struct{}{}
-
 	t.addOpCodeToAccount(addr, vm.SLOAD)
 }
 

--- a/eth/tracers/native/zero.go
+++ b/eth/tracers/native/zero.go
@@ -333,10 +333,6 @@ func (t *zeroTracer) addAccountToTrace(addr libcommon.Address) {
 		return
 	}
 
-	if !t.env.IntraBlockState().HasLiveAccount(addr) {
-		return
-	}
-
 	nonce := uint256.NewInt(t.env.IntraBlockState().GetNonce(addr))
 	codeHash := t.env.IntraBlockState().GetCodeHash(addr)
 


### PR DESCRIPTION
This should be a safe change since we also do check if the object is actually in the live set by the end of transaction (see [this commit](https://github.com/0xPolygonZero/erigon/commit/b62bf09569a8507b11447e8e14478e048d54a558)).